### PR TITLE
Github activity frontend changes

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -280,7 +280,8 @@ class EndpointTests(TestCase):
         self.client.login(username='1', password='123')
         user = {
             "username": "new",
-            "password": "456"
+            "password": "456",
+            "github": "",
         }
         author_id = self.user1.id
         response = self.client.put('/api/author/{}/'.format(author_id), user, content_type="application/json")

--- a/api/views.py
+++ b/api/views.py
@@ -462,8 +462,7 @@ def profile(request, aid):
             if len(json_body["password"]) != 0:
                 author.password = json_body["password"]
 
-            if len(json_body.get("github",'')) != 0:
-                author.github = json_body["github"]
+            author.github = json_body["github"]
 
             author.save()
             response_body = JSONRenderer().render({

--- a/api/views_/login.py
+++ b/api/views_/login.py
@@ -31,7 +31,8 @@ def login(request):
         if request.user.is_authenticated:
             return JsonResponse({
                     'id': request.user.id,
-                    'username': request.user.username
+                    'username': request.user.username,
+                    'github': request.user.github,
                 })
         else:
             return HttpResponseBadRequest("Not logged in")

--- a/social_frontend/components/Editor.js
+++ b/social_frontend/components/Editor.js
@@ -7,7 +7,11 @@ import Markdown from './Markdown';
 import Attachments from './Attachments';
 import TagBar from './common/TagBar';
 import EditorUserBar from './EditorUserBar';
-import { imageAbsoluteURL, submitPostEndpoint } from '../util/endpoints';
+import {
+  imageAbsoluteURL,
+  submitPostEndpoint,
+  triggerGithubEndpoint,
+} from '../util/endpoints';
 
 import '../styles/editor.css';
 
@@ -190,7 +194,7 @@ class PostForm extends React.Component {
 
     const { id, submittedCallback } = this.props;
 
-    return Axios.get(`/api/author/${id}/github/`).then((res) => {
+    return Axios.get(triggerGithubEndpoint(id)).then((res) => {
       submittedCallback(res.data.post);
     }).catch((err) => {
       console.log(err);
@@ -456,6 +460,7 @@ class PostForm extends React.Component {
       isComment,
       isPatching,
       onCancel,
+      hasGithub,
     } = this.props;
     const {
       textContent,
@@ -476,6 +481,7 @@ class PostForm extends React.Component {
 
     const className = `post-form ${isComment ? 'comment-form' : ''} ${isMarkdown ? 'markdown-mode' : ''}`;
     const placeholder = isComment ? 'Add a comment' : 'Post to your stream';
+
     return (
       <form onSubmit={this.handleSubmit} className={className}>
         <div className="post-form-mode-controls">
@@ -587,7 +593,16 @@ class PostForm extends React.Component {
           isPatching={isPatching}
           visibility={visibility}
         />
-        <input className="github" type="submit" value="Post GitHub" onClick={this.handleGitHubPost} />
+        {
+          hasGithub && (
+            <input
+              className="github"
+              type="submit"
+              value="Post GitHub"
+              onClick={this.handleGitHubPost}
+            />
+          )
+        }
       </form>
     );
   }
@@ -596,6 +611,7 @@ class PostForm extends React.Component {
 PostForm.propTypes = {
   isComment: PropTypes.bool,
   isPatching: PropTypes.bool,
+  hasGithub: PropTypes.bool,
   submittedCallback: PropTypes.func,
   defaultContent: PropTypes.string,
   defaultTitle: PropTypes.string,
@@ -619,6 +635,7 @@ PostForm.propTypes = {
 PostForm.defaultProps = {
   isComment: false,
   isPatching: false,
+  hasGithub: false,
   submittedCallback: undefined,
   defaultContent: '',
   defaultTitle: '',
@@ -633,6 +650,7 @@ PostForm.defaultProps = {
 
 const mapStateToProps = (state) => ({
   id: state.id,
+  hasGithub: state.github && state.github.length > 0,
 });
 
 export default connect(mapStateToProps)(PostForm);

--- a/social_frontend/pages/EditProfilePage.js
+++ b/social_frontend/pages/EditProfilePage.js
@@ -8,9 +8,7 @@ import SuspensefulSubmit from '../components/common/suspend/SuspensefulSubmit';
 
 import '../styles/login.css';
 
-
-/* Page displaying a login form. */
-class EditProfilePage extends React.Component {
+class EditProfileFormM extends React.Component {
   state = {
     enteredUsername: '',
     enteredPassword1: '',
@@ -26,6 +24,14 @@ class EditProfilePage extends React.Component {
     this.handlePassword2FieldChange = this.handlePassword2FieldChange.bind(this);
     this.handleGitHubFieldChange = this.handleGitHubFieldChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  componentDidMount() {
+    const { username, github } = this.props;
+    this.setState({
+      enteredUsername: username,
+      github,
+    });
   }
 
   handleUsernameFieldChange(event) {
@@ -86,12 +92,9 @@ class EditProfilePage extends React.Component {
       github,
     } = this.state;
 
-    const { errorMessage, loading } = this.props;
+    const { id, errorMessage, loading } = this.props;
 
-    const enableSubmit = enteredUsername.length > 0
-      || (enteredPassword1.length > 0 && enteredPassword2.length)
-      || github;
-
+    if (id === null) return null;
 
     return (
       <div className="login-page-wrapper">
@@ -135,7 +138,6 @@ class EditProfilePage extends React.Component {
             }
             <SuspensefulSubmit
               label="Edit Profile"
-              disabled={!enableSubmit}
               suspended={loading}
             />
           </form>
@@ -146,17 +148,21 @@ class EditProfilePage extends React.Component {
   }
 }
 
-EditProfilePage.propTypes = {
+EditProfileFormM.propTypes = {
   errorMessage: PropTypes.string,
   loading: PropTypes.bool,
   onEdit: PropTypes.func.isRequired,
   id: PropTypes.string,
+  username: PropTypes.string,
+  github: PropTypes.string,
 };
 
-EditProfilePage.defaultProps = {
+EditProfileFormM.defaultProps = {
   errorMessage: null,
   loading: false,
-  id: '',
+  id: null,
+  username: '',
+  github: '',
 };
 
 const mapStateToProps = ({
@@ -164,11 +170,13 @@ const mapStateToProps = ({
   errorMessage,
   id,
   username,
+  github,
 }) => ({
   loading,
   errorMessage,
   id,
   username,
+  github,
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -178,4 +186,28 @@ const mapDispatchToProps = (dispatch) => ({
   )),
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(EditProfilePage);
+const EditProfileForm = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(EditProfileFormM);
+
+
+const EditProfilePage = ({ id }) => (
+  id ? <EditProfileForm key={id} /> : null
+);
+
+EditProfilePage.propTypes = {
+  id: PropTypes.string,
+};
+
+EditProfilePage.defaultProps = {
+  id: null,
+};
+
+const mapStateToPropsForPage = ({
+  id,
+}) => ({
+  id,
+});
+
+export default connect(mapStateToPropsForPage)(EditProfilePage);

--- a/social_frontend/pages/RegistrationPage.js
+++ b/social_frontend/pages/RegistrationPage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Axios from 'axios';
 import { Link } from 'react-router-dom';
 
@@ -175,11 +174,5 @@ class RegistrationPage extends React.Component {
     );
   }
 }
-
-RegistrationPage.propTypes = {
-  history: PropTypes.shape({
-    push: PropTypes.func.isRequired,
-  }).isRequired,
-};
 
 export default RegistrationPage;

--- a/social_frontend/store/actions/auth.js
+++ b/social_frontend/store/actions/auth.js
@@ -93,16 +93,15 @@ export const authCheckState = () => (
   }
 );
 
-export const setUserData = (id, username) => ({
+export const setUserData = (userData) => ({
   type: actionTypes.SET_USER,
-  id,
-  username,
+  ...userData,
 });
 
 export const getUser = () => (
   (dispatch) => {
     axios.get(loggedInUserEndpoint()).then((res) => (
-      dispatch(setUserData(res.data.id, res.data.username))
+      dispatch(setUserData(res.data))
     )).catch((err) => {
       Error(err);
     });
@@ -140,6 +139,7 @@ export const editUser = (id, username, password, password2, github) => (
         github,
       }).then(() => {
         dispatch(editSuccess());
+        dispatch(setUserData({ username, github }));
         window.location.reload();
       }).catch((err) => {
         dispatch(editFail(err.message));

--- a/social_frontend/store/reducers/auth.js
+++ b/social_frontend/store/reducers/auth.js
@@ -17,6 +17,7 @@ const initState = {
   loading: false,
   id: null,
   username: null,
+  github: null,
 };
 
 const authStart = (state) => (
@@ -47,6 +48,7 @@ const authLogout = (state) => (
     authenticated: false,
     id: null,
     username: null,
+    github: null,
   })
 );
 
@@ -54,6 +56,7 @@ const setUserData = (state, action) => (
   updateObject(state, {
     id: action.id,
     username: action.username,
+    github: action.github,
   })
 );
 

--- a/social_frontend/util/endpoints.js
+++ b/social_frontend/util/endpoints.js
@@ -68,3 +68,7 @@ export const logoutEndpoint = () => (
 export const loggedInUserEndpoint = () => (
   '/api/login/'
 );
+
+export const triggerGithubEndpoint = (id) => (
+  `/api/author/${id}/github/`
+);


### PR DESCRIPTION
Hide "post github activity" button if logged-in user has no github url
Allow setting the github url to empty when editing profile
Populate the profile editor fields (except password of course) with their current values